### PR TITLE
Set Background fails for activity charts. 

### DIFF
--- a/packages/ibm-gantt-chart-dev/src/activityChart/activityChart.html
+++ b/packages/ibm-gantt-chart-dev/src/activityChart/activityChart.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <title>Simple Gantt</title>
+
+    <!--  Page styles  -->
+    <style>
+      html {
+        height: 100%;
+      }
+      body {
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+      #gantt {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="gantt"></div>
+  </body>
+</html>

--- a/packages/ibm-gantt-chart-dev/src/activityChart/activityChart.js
+++ b/packages/ibm-gantt-chart-dev/src/activityChart/activityChart.js
@@ -1,0 +1,102 @@
+// import '@babel/polyfill';
+
+import Gantt from 'ibm-gantt-chart';
+
+// useless with mainFields: ['source'],
+// import 'ibm-gantt-chart/dist/ibm-gantt-chart.css';
+
+var activityData = [
+  {
+    OBJ_ID: 'NURSES+Anne',
+    NAME: 'Anne',
+    START: 1646162596336,
+    END: 1646165596336,
+    PARENT_ID: null,
+    COLOR: '#FF0000',
+    URL: 'https://example.com/?link-to-anne',
+  },
+  {
+    OBJ_ID: 'NURSES+Bethanie',
+    NAME: 'Bethanie',
+    START: 1646163596336,
+    END: 1646164596336,
+    PARENT_ID: 'NURSES+Anne',
+    COLOR: '#0000FF',
+    URL: 'https://example.com/?link-to-bethanie',
+  },
+  {
+    OBJ_ID: 'NURSES+Betsy',
+    NAME: 'Betsy',
+    START: 1646164596336,
+    END: 1646165596336,
+    PARENT_ID: 'NURSES+Bethanie',
+    COLOR: '#FFA500',
+    URL: 'https://example.com/?link-to-betsy',
+  },
+  {
+    OBJ_ID: 'NURSES+Cathy',
+    NAME: 'Cathy',
+    START: 1646163596336,
+    END: 1646165596336,
+    parent: null,
+    COLOR: '#008000',
+    URL: 'https://example.com/?link-to-cathy',
+  },
+  {
+    OBJ_ID: 'NURSES+Cindy',
+    NAME: 'Cindy',
+    START: 1646164596336,
+    END: 1646165596336,
+    PARENT_ID: 'NURSES+Cathy',
+    COLOR: '#FFFF00',
+    URL: 'https://example.com/?nurse=link-to-cindy',
+  },
+];
+
+function createActivitiesGanttConfig() {
+  return {
+    data: {
+      activities: {
+        data: activityData,
+        parent: 'PARENT_ID',
+        id: 'OBJ_ID',
+        name: 'NAME',
+        start: 'START',
+        end: 'END',
+      },
+    },
+    timeTable: {
+      renderer: [
+        {
+          background: (a, b) => a.getData().COLOR,
+          color: (a, b) => '#ffffff',
+          textOverflow: 'cut',
+        },
+      ],
+    },
+    type: Gantt.type.ACTIVITY_CHART,
+    toolbar: [
+      'title',
+      {
+        type: 'button',
+        text: 'Refresh',
+        fontIcon: 'fa fa-refresh fa-lg',
+        onclick(ctx) {
+          location.reload();
+        },
+      },
+      'separator',
+      'search',
+      'separator',
+      'mini',
+      'separator',
+      'fitToContent',
+      'zoomIn',
+      'zoomOut',
+      'separator',
+    ],
+    title: 'Riot Games',
+  };
+}
+
+new Gantt('gantt' /* the id of the DOM element to contain the Gantt chart */, createActivitiesGanttConfig());

--- a/packages/ibm-gantt-chart/src/timetable/activityrenderer.js
+++ b/packages/ibm-gantt-chart/src/timetable/activityrenderer.js
@@ -172,13 +172,17 @@ const ActivityRendererPrototype = {
       } else {
         // TODO Don't put a setter in a get...
         this.setBackground = function(shapeElt, bg) {
-          if (Gantt.utils.hasClass('parent-activity')) {
+          if (Gantt.utils.hasClass(shapeElt, 'parent-activity')) {
             shapeElt.querySelectorAll('.activity-limit').forEach(elt => {
-              elt.style.borderColor = bg;
+              elt.style.borderTopColor = bg;
             });
-            shapeElt.querySelector('parent-activity-bar').style.backgroundColor = bg;
+            const parentBar = shapeElt.querySelector('.parent-activity-bar');
+            if (parentBar) {
+              parentBar.style.backgroundColor = bg;
+            }
           } else {
-            this.drawDefaultContentSet(shapeElt, bg);
+            this.drawDefaultContentSet(shapeElt, null, '');
+            shapeElt.style.backgroundColor = bg;
           }
         };
         this.drawDefaultContent = this.drawRightContent;


### PR DESCRIPTION
After attempting to change the colors of the activity bars in an Activity chart I found that the activity renderer was not functioning properly. 

After running the chrome debugger I was able to determine that the Gantt.utils.hasClass() accepts 2 parameters:

![image](https://user-images.githubusercontent.com/3604887/156286762-9ab8096e-210d-4e58-8bb1-5083465f6d14.png)

but in the activity renderer only passes the class its checking for: 
![image](https://user-images.githubusercontent.com/3604887/156286957-2119b545-3608-4b41-bb4e-1414b04dec17.png)

There were some other errors that I fixed inside the setBackground function. 

It works for me now, and I have added an example of using the activity chart with colors in the ibm-gantt-chart-dev package. 